### PR TITLE
Fix: Add to_hash to wrap Hash and Session classes

### DIFF
--- a/lib/rack/session/abstract/id.rb
+++ b/lib/rack/session/abstract/id.rb
@@ -182,7 +182,7 @@ module Rack
         end
 
         def stringify_keys(other)
-          other.transform_keys(&:to_s)
+          other.to_hash.transform_keys(&:to_s)
         end
       end
 


### PR DESCRIPTION
Quick fix to support Hash and Session classes